### PR TITLE
Set default UserId and GroupId to 0:0

### DIFF
--- a/pkg/util/command_util.go
+++ b/pkg/util/command_util.go
@@ -347,7 +347,7 @@ Loop:
 
 func GetUserGroup(chownStr string, env []string) (int64, int64, error) {
 	if chownStr == "" {
-		return DoNotChangeUID, DoNotChangeGID, nil
+		return 0, 0, nil
 	}
 
 	chown, err := ResolveEnvironmentReplacement(chownStr, env, false)

--- a/pkg/util/command_util_test.go
+++ b/pkg/util/command_util_test.go
@@ -561,8 +561,8 @@ func TestGetUserGroup(t *testing.T) {
 			mockIDGetter: func(string, string, bool) (uint32, uint32, error) {
 				return 0, 0, fmt.Errorf("should not be called")
 			},
-			expectedU: -1,
-			expectedG: -1,
+			expectedU: 0,
+			expectedG: 0,
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Cherry-pick kaniko patch, this should help resolve https://github.com/coder/envbuilder/issues/70

Update to match Dockerfile specifications when using ADD or COPY Previous functionality was to preserve the user and group from the source, which may not exist in the container.

@kylecarbs what do you think?