### PR TITLE
Add extraction progress output to GetFSFromImage/GetFSFromLayers

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -193,14 +193,14 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 	var extractedBytes int64
 	for i, l := range layers {
 		if mediaType, err := l.MediaType(); err == nil {
-			logrus.Tracef("Extracting layer %d of media type %s", i, mediaType)
+			logrus.Tracef("Extracting layer %d/%d of media type %s", i+1, len(layers), mediaType)
 		} else {
-			logrus.Tracef("Extracting layer %d", i)
+			logrus.Tracef("Extracting layer %d/%d", i+1, len(layers))
 		}
 
 		progressPerc := float64(extractedBytes) / float64(totalSize) * 100
 		if printExtractionProgress {
-			logrus.Infof("Extracting layer %d (%.1f%%)", i, progressPerc)
+			logrus.Infof("Extracting layer %d/%d (%.1f%%)", i+1, len(layers), progressPerc)
 		}
 
 		r, err := l.Uncompressed()
@@ -214,7 +214,7 @@ func GetFSFromLayers(root string, layers []v1.Layer, opts ...FSOpt) ([]string, e
 				ReadCloser: r,
 				after:      time.Second,
 				print: func(n int) {
-					logrus.Infof("Extracting layer %d (%.1f%%) %s", i, progressPerc, strings.Repeat(".", n))
+					logrus.Infof("Extracting layer %d/%d (%.1f%%) %s", i+1, len(layers), progressPerc, strings.Repeat(".", n))
 				},
 			}
 		}

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1067,6 +1067,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc := io.NopCloser(buf)
@@ -1082,6 +1083,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 	f(secondLayerFiles, tw)
 
 	mockLayer2 := mockv1.NewMockLayer(ctrl)
+	mockLayer2.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer2.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc = io.NopCloser(buf)
@@ -1175,6 +1177,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 	layerFiles := []string{
 		filepath.Join(root, "foobar"),
@@ -1197,6 +1200,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 	f(secondLayerFiles, tw)
 
 	mockLayer2 := mockv1.NewMockLayer(ctrl)
+	mockLayer2.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer2.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc = io.NopCloser(buf)
@@ -1280,6 +1284,7 @@ func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 	layerFiles := []string{
 		filepath.Join(root, ".wh.testdir"),
@@ -1344,6 +1349,8 @@ func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 	tw = tar.NewWriter(buf)
 
 	f(layerFiles, tw)
+
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 
 	rc = io.NopCloser(buf)
 	mockLayer.EXPECT().Uncompressed().Return(rc, nil)
@@ -1410,6 +1417,7 @@ func Test_GetFSFromLayers(t *testing.T) {
 	}
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc := io.NopCloser(buf)


### PR DESCRIPTION
This PR allows printing extraction progress during unpack. Since we can't access the underlying reader for the compressed data, we can only print accurate progress at every layer change. Instead we print `...` every 1 second (triggered via read) to indicate that the extraction is still in progress.

Fixes https://github.com/coder/envbuilder/issues/124

```
#2: Building stage 'mcr.microsoft.com/devcontainers/typescript-node:18-bookworm' [idx: '1', base-idx: '-1']
#2: Unpacking rootfs as cmd ADD install-vscode.sh /root/ requires it.
#2: Extracting image layers to /
#2: Extracting layer 1/22 (0.0%)
#2: Extracting layer 1/22 (0.0%) .
#2: Extracting layer 1/22 (0.0%) ..
#2: Extracting layer 2/22 (7.6%)
#2: Extracting layer 3/22 (11.3%)
#2: Extracting layer 3/22 (11.3%) .
#2: Extracting layer 3/22 (11.3%) ..
#2: Extracting layer 4/22 (21.1%)
#2: Extracting layer 4/22 (21.1%) .
#2: Extracting layer 4/22 (21.1%) ..
#2: Extracting layer 4/22 (21.1%) ...
#2: Extracting layer 4/22 (21.1%) ....
#2: Extracting layer 4/22 (21.1%) .....
#2: Extracting layer 4/22 (21.1%) ......
#2: Extracting layer 5/22 (53.4%)
#2: Extracting layer 6/22 (53.4%)
#2: Extracting layer 6/22 (53.4%) .
#2: Extracting layer 7/22 (60.4%)
#2: Extracting layer 8/22 (60.6%)
#2: Extracting layer 9/22 (60.6%)
#2: Extracting layer 10/22 (61.5%)
#2: Extracting layer 11/22 (61.5%)
#2: Extracting layer 12/22 (61.5%)
#2: Extracting layer 13/22 (61.5%)
#2: Extracting layer 14/22 (61.5%)
#2: Extracting layer 14/22 (61.5%) .
#2: Extracting layer 14/22 (61.5%) ..
#2: Extracting layer 15/22 (72.1%)
#2: Extracting layer 15/22 (72.1%) .
#2: Extracting layer 16/22 (82.0%)
#2: Extracting layer 17/22 (83.6%)
#2: Extracting layer 17/22 (83.6%) .
#2: Extracting layer 18/22 (90.5%)
#2: Extracting layer 19/22 (90.5%)
#2: Extracting layer 20/22 (90.5%)
#2: Extracting layer 21/22 (90.5%)
#2: Extracting layer 22/22 (90.5%)
#2: Extracting layer 22/22 (90.5%) .
#2: Extraction complete
#2: Using files from context: [/workspaces/vscode/.devcontainer/install-vscode.sh]
```
