### PR TITLE
Add support for fake, and speed up reproducible builds

### DIFF
--- a/pkg/commands/cache.go
+++ b/pkg/commands/cache.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package commands
 
-import v1 "github.com/google/go-containerregistry/pkg/v1"
+import (
+	"github.com/GoogleContainerTools/kaniko/pkg/dockerfile"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
 
 type Cached interface {
 	Layer() v1.Layer
@@ -28,4 +31,8 @@ type caching struct {
 
 func (c caching) Layer() v1.Layer {
 	return c.layer
+}
+
+type FakeExecuteCommand interface {
+	FakeExecuteCommand(*v1.Config, *dockerfile.BuildArgs) error
 }

--- a/pkg/commands/copy.go
+++ b/pkg/commands/copy.go
@@ -206,6 +206,29 @@ func (cr *CachingCopyCommand) ExecuteCommand(config *v1.Config, buildArgs *docke
 	return nil
 }
 
+func (cr *CachingCopyCommand) FakeExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
+	logrus.Infof("Found cached layer, faking extraction to filesystem")
+	var err error
+
+	if cr.img == nil {
+		return errors.New(fmt.Sprintf("cached command image is nil %v", cr.String()))
+	}
+
+	layers, err := cr.img.Layers()
+	if err != nil {
+		return errors.Wrapf(err, "retrieve image layers")
+	}
+
+	if len(layers) != 1 {
+		return errors.New(fmt.Sprintf("expected %d layers but got %d", 1, len(layers)))
+	}
+
+	cr.layer = layers[0]
+	cr.extractedFiles = []string{}
+
+	return nil
+}
+
 func (cr *CachingCopyCommand) FilesUsedFromContext(config *v1.Config, buildArgs *dockerfile.BuildArgs) ([]string, error) {
 	return copyCmdFilesUsedFromContext(config, buildArgs, cr.cmd, cr.fileContext)
 }

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -115,7 +115,7 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 	if !opts.Reproducible {
 		snapshotter = snapshot.NewSnapshotter(l, config.RootDir)
 	} else {
-		snapshotter = snapshot.NewCanonicalSnapshotter(l, config.RootDir)
+		snapshotter = snapshot.NewReproducibleSnapshotter(l, config.RootDir)
 	}
 
 	digest, err := sourceImage.Digest()

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -111,7 +111,12 @@ func newStageBuilder(args *dockerfile.BuildArgs, opts *config.KanikoOptions, sta
 		return nil, err
 	}
 	l := snapshot.NewLayeredMap(hasher)
-	snapshotter := snapshot.NewSnapshotter(l, config.RootDir)
+	var snapshotter snapShotter
+	if !opts.Reproducible {
+		snapshotter = snapshot.NewSnapshotter(l, config.RootDir)
+	} else {
+		snapshotter = snapshot.NewCanonicalSnapshotter(l, config.RootDir)
+	}
 
 	digest, err := sourceImage.Digest()
 	if err != nil {
@@ -439,6 +444,92 @@ func (s *stageBuilder) build() error {
 
 	if err := cacheGroup.Wait(); err != nil {
 		logrus.Warnf("Error uploading layer to cache: %s", err)
+	}
+
+	return nil
+}
+
+// fakeBuild is like build(), but does not actually execute the commands or
+// extract files.
+func (s *stageBuilder) fakeBuild() error {
+	// Set the initial cache key to be the base image digest, the build args and the SrcContext.
+	var compositeKey *CompositeCache
+	if cacheKey, ok := s.digestToCacheKey[s.baseImageDigest]; ok {
+		compositeKey = NewCompositeCache(cacheKey)
+	} else {
+		compositeKey = NewCompositeCache(s.baseImageDigest)
+	}
+
+	// Apply optimizations to the instructions.
+	if err := s.optimize(*compositeKey, s.cf.Config); err != nil {
+		return errors.Wrap(err, "failed to optimize instructions")
+	}
+
+	for index, command := range s.cmds {
+		if command == nil {
+			continue
+		}
+
+		// If the command uses files from the context, add them.
+		files, err := command.FilesUsedFromContext(&s.cf.Config, s.args)
+		if err != nil {
+			return errors.Wrap(err, "failed to get files used from context")
+		}
+
+		if s.opts.Cache {
+			*compositeKey, err = s.populateCompositeKey(command, files, *compositeKey, s.args, s.cf.Config.Env)
+			if err != nil && s.opts.Cache {
+				return err
+			}
+		}
+
+		logrus.Info(command.String())
+
+		isCacheCommand := func() bool {
+			switch command.(type) {
+			case commands.Cached:
+				return true
+			default:
+				return false
+			}
+		}()
+
+		if c, ok := command.(commands.FakeExecuteCommand); ok {
+			if err := c.FakeExecuteCommand(&s.cf.Config, s.args); err != nil {
+				return errors.Wrap(err, "failed to execute fake command")
+			}
+		} else {
+			switch command.(type) {
+			case *commands.UserCommand:
+			default:
+				return errors.Errorf("uncached command %T is not supported in fake build", command)
+			}
+			if err := command.ExecuteCommand(&s.cf.Config, s.args); err != nil {
+				return errors.Wrap(err, "failed to execute command")
+			}
+		}
+		files = command.FilesToSnapshot()
+
+		if !s.shouldTakeSnapshot(index, command.MetadataOnly()) && !s.opts.ForceBuildMetadata {
+			logrus.Debugf("fakeBuild: skipping snapshot for [%v]", command.String())
+			continue
+		}
+		if isCacheCommand {
+			v := command.(commands.Cached)
+			layer := v.Layer()
+			if err := s.saveLayerToImage(layer, command.String()); err != nil {
+				return errors.Wrap(err, "failed to save layer")
+			}
+		} else {
+			tarPath, err := s.takeSnapshot(files, command.ShouldDetectDeletedFiles())
+			if err != nil {
+				return errors.Wrap(err, "failed to take snapshot")
+			}
+
+			if err := s.saveSnapshotToImage(command.String(), tarPath); err != nil {
+				return errors.Wrap(err, "failed to save snapshot to image")
+			}
+		}
 	}
 
 	return nil
@@ -787,7 +878,9 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 				return nil, err
 			}
 			if opts.Reproducible {
-				sourceImage, err = mutate.Canonical(sourceImage)
+				// If this option is enabled, we will use the canonical
+				// snapshotter to avoid having to modify the layers here.
+				sourceImage, err = mutateCanonicalWithoutLayerEdit(sourceImage)
 				if err != nil {
 					return nil, err
 				}
@@ -797,6 +890,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 					return nil, err
 				}
 			}
+
 			timing.DefaultRun.Stop(t)
 			return sourceImage, nil
 		}
@@ -831,6 +925,140 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 	}
 
 	return nil, err
+}
+
+// DoFakeBuild executes building the Dockerfile without modifying the
+// filesystem, returns an error if build cache is not available.
+func DoFakeBuild(opts *config.KanikoOptions) (v1.Image, error) {
+	digestToCacheKey := make(map[string]string)
+	stageIdxToDigest := make(map[string]string)
+
+	stages, metaArgs, err := dockerfile.ParseStages(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	kanikoStages, err := dockerfile.MakeKanikoStages(opts, stages, metaArgs)
+	if err != nil {
+		return nil, err
+	}
+	stageNameToIdx := ResolveCrossStageInstructions(kanikoStages)
+
+	fileContext, err := util.NewFileContextFromDockerfile(opts.DockerfilePath, opts.SrcContext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Some stages may refer to other random images, not previous stages
+	if err := fetchExtraStages(kanikoStages, opts); err != nil {
+		return nil, err
+	}
+	crossStageDependencies, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
+	if err != nil {
+		return nil, err
+	}
+	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
+
+	var args *dockerfile.BuildArgs
+
+	for _, stage := range kanikoStages {
+		sb, err := newStageBuilder(
+			args, opts, stage,
+			crossStageDependencies,
+			digestToCacheKey,
+			stageIdxToDigest,
+			stageNameToIdx,
+			fileContext)
+		if err != nil {
+			return nil, err
+		}
+
+		args = sb.args
+		if err := sb.fakeBuild(); err != nil {
+			return nil, errors.Wrap(err, "error fake building stage")
+		}
+
+		reviewConfig(stage, &sb.cf.Config)
+
+		sourceImage, err := mutate.Config(sb.image, sb.cf.Config)
+		if err != nil {
+			return nil, err
+		}
+
+		configFile, err := sourceImage.ConfigFile()
+		if err != nil {
+			return nil, err
+		}
+		if opts.CustomPlatform == "" {
+			configFile.OS = runtime.GOOS
+			configFile.Architecture = runtime.GOARCH
+		} else {
+			configFile.OS = strings.Split(opts.CustomPlatform, "/")[0]
+			configFile.Architecture = strings.Split(opts.CustomPlatform, "/")[1]
+		}
+		sourceImage, err = mutate.ConfigFile(sourceImage, configFile)
+		if err != nil {
+			return nil, err
+		}
+
+		d, err := sourceImage.Digest()
+		if err != nil {
+			return nil, err
+		}
+		stageIdxToDigest[fmt.Sprintf("%d", sb.stage.Index)] = d.String()
+		logrus.Infof("Mapping stage idx %v to digest %v", sb.stage.Index, d.String())
+
+		digestToCacheKey[d.String()] = sb.finalCacheKey
+		logrus.Infof("Mapping digest %v to cachekey %v", d.String(), sb.finalCacheKey)
+
+		if stage.Final {
+			sourceImage, err = mutateCanonicalWithoutLayerEdit(sourceImage)
+			if err != nil {
+				return nil, err
+			}
+
+			return sourceImage, nil
+		}
+	}
+
+	return nil, err
+}
+
+// From mutate.Canonical with layer de/compress stripped out.
+func mutateCanonicalWithoutLayerEdit(image v1.Image) (v1.Image, error) {
+	t := time.Time{}
+
+	ocf, err := image.ConfigFile()
+	if err != nil {
+		return nil, fmt.Errorf("setting config file: %w", err)
+	}
+
+	cfg := ocf.DeepCopy()
+
+	// Copy basic config over
+	cfg.Architecture = ocf.Architecture
+	cfg.OS = ocf.OS
+	cfg.OSVersion = ocf.OSVersion
+	cfg.Config = ocf.Config
+
+	// Strip away timestamps from the config file
+	cfg.Created = v1.Time{Time: t}
+
+	for i, h := range cfg.History {
+		h.Created = v1.Time{Time: t}
+		h.CreatedBy = ocf.History[i].CreatedBy
+		h.Comment = ocf.History[i].Comment
+		h.EmptyLayer = ocf.History[i].EmptyLayer
+		// Explicitly ignore Author field; which hinders reproducibility
+		h.Author = ""
+		cfg.History[i] = h
+	}
+
+	cfg.Container = ""
+	cfg.Config.Hostname = ""
+	cfg.DockerVersion = ""
+
+	return mutate.ConfigFile(image, cfg)
 }
 
 // filesToSave returns all the files matching the given pattern in deps.

--- a/pkg/executor/cache_probe_test.go
+++ b/pkg/executor/cache_probe_test.go
@@ -1,0 +1,155 @@
+package executor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/GoogleContainerTools/kaniko/pkg/config"
+	"github.com/GoogleContainerTools/kaniko/pkg/constants"
+	"github.com/GoogleContainerTools/kaniko/testutil"
+)
+
+func TestDoCacheProbe(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		testDir, fn := setupCacheProbeTests(t)
+		defer fn()
+		dockerFile := `FROM scratch
+COPY foo/bar.txt copied/
+`
+		os.WriteFile(filepath.Join(testDir, "workspace", "Dockerfile"), []byte(dockerFile), 0755)
+		// Populate the cache by doing an initial build
+		cacheDir := t.TempDir()
+		opts := &config.KanikoOptions{
+			DockerfilePath: filepath.Join(testDir, "workspace", "Dockerfile"),
+			SrcContext:     filepath.Join(testDir, "workspace"),
+			SnapshotMode:   constants.SnapshotModeFull,
+			Cache:          true,
+			CacheOptions: config.CacheOptions{
+				CacheTTL: time.Hour,
+			},
+			CacheCopyLayers: true,
+			CacheRunLayers:  true,
+			CacheRepo:       "oci:/" + cacheDir,
+		}
+		_, err := DoCacheProbe(opts)
+		if err == nil || !strings.Contains(err.Error(), "not supported in fake build") {
+			t.Errorf("unexpected error, got %v", err)
+		}
+	})
+
+	t.Run("Present", func(t *testing.T) {
+		testDir, fn := setupCacheProbeTests(t)
+		defer fn()
+		dockerFile := `FROM scratch
+COPY foo/bar.txt copied/
+`
+		os.WriteFile(filepath.Join(testDir, "workspace", "Dockerfile"), []byte(dockerFile), 0755)
+		cacheDir := t.TempDir()
+		opts := &config.KanikoOptions{
+			DockerfilePath: filepath.Join(testDir, "workspace", "Dockerfile"),
+			SrcContext:     filepath.Join(testDir, "workspace"),
+			SnapshotMode:   constants.SnapshotModeRedo,
+			Cache:          true,
+			CacheOptions: config.CacheOptions{
+				CacheTTL: time.Hour,
+			},
+			CacheCopyLayers: true,
+			CacheRunLayers:  true,
+			CacheRepo:       "oci:/" + cacheDir,
+		}
+		_, err := DoBuild(opts)
+		testutil.CheckNoError(t, err)
+		opts.Reproducible = true
+		_, err = DoCacheProbe(opts)
+		testutil.CheckNoError(t, err)
+	})
+
+	t.Run("Partial", func(t *testing.T) {
+		testDir, fn := setupCacheProbeTests(t)
+		defer fn()
+		dockerFile := `FROM scratch
+COPY foo/bar.txt copied/
+`
+		os.WriteFile(filepath.Join(testDir, "workspace", "Dockerfile"), []byte(dockerFile), 0755)
+		cacheDir := t.TempDir()
+		opts := &config.KanikoOptions{
+			DockerfilePath: filepath.Join(testDir, "workspace", "Dockerfile"),
+			SrcContext:     filepath.Join(testDir, "workspace"),
+			SnapshotMode:   constants.SnapshotModeFull,
+			Cache:          true,
+			CacheOptions: config.CacheOptions{
+				CacheTTL: time.Hour,
+			},
+			CacheCopyLayers: true,
+			CacheRunLayers:  true,
+			CacheRepo:       "oci:/" + cacheDir,
+		}
+		_, err := DoBuild(opts)
+		testutil.CheckNoError(t, err)
+		opts.Reproducible = true
+
+		// Modify the Dockerfile to add some extra steps
+		dockerFile = `FROM scratch
+COPY foo/bar.txt copied/
+COPY foo/baz.txt copied/
+`
+		os.WriteFile(filepath.Join(testDir, "workspace", "Dockerfile"), []byte(dockerFile), 0755)
+		_, err = DoCacheProbe(opts)
+		if err == nil || !strings.Contains(err.Error(), "not supported in fake build") {
+			t.Errorf("unexpected error, got %v", err)
+		}
+	})
+}
+
+func setupCacheProbeTests(t *testing.T) (string, func()) {
+	testDir := t.TempDir()
+	// Create workspace with files, dirs, and symlinks
+	// workspace tree:
+	// /root
+	//    /kaniko
+	//    /workspace
+	//     - /foo
+	//          - bar.txt
+	//          - baz.txt
+	if err := os.MkdirAll(filepath.Join(testDir, "kaniko/0"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	workspace := filepath.Join(testDir, "workspace")
+	// Make foo
+	if err := os.MkdirAll(filepath.Join(workspace, "foo"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	file := filepath.Join(workspace, "foo", "bar.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	file2 := filepath.Join(workspace, "foo", "baz.txt")
+	if err := os.WriteFile(file2, []byte("world"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// set up config
+	config.RootDir = testDir
+	config.KanikoDir = fmt.Sprintf("%s/%s", testDir, "kaniko")
+	// Write path to ignore list
+	if err := os.MkdirAll(filepath.Join(testDir, "proc"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	mFile := filepath.Join(testDir, "proc/mountinfo")
+	mountInfo := fmt.Sprintf(
+		`36 35 98:0 /kaniko %s/kaniko rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+36 35 98:0 /proc %s/proc rw,noatime master:1 - ext3 /dev/root rw,errors=continue
+`, testDir, testDir)
+	if err := os.WriteFile(mFile, []byte(mountInfo), 0644); err != nil {
+		t.Fatal(err)
+	}
+	config.MountInfoPath = mFile
+	return testDir, func() {
+		config.RootDir = constants.RootDir
+		config.MountInfoPath = constants.MountInfoPath
+	}
+}

--- a/pkg/executor/cache_probe_test.go
+++ b/pkg/executor/cache_probe_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package executor
 
 import (

--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -39,10 +39,10 @@ var snapshotPathPrefix = ""
 
 // Snapshotter holds the root directory from which to take snapshots, and a list of snapshots taken
 type Snapshotter struct {
-	l          *LayeredMap
-	directory  string
-	ignorelist []util.IgnoreListEntry
-	canonical  bool
+	l            *LayeredMap
+	directory    string
+	ignorelist   []util.IgnoreListEntry
+	reproducible bool
 }
 
 // NewSnapshotter creates a new snapshotter rooted at d
@@ -50,10 +50,10 @@ func NewSnapshotter(l *LayeredMap, d string) *Snapshotter {
 	return &Snapshotter{l: l, directory: d, ignorelist: util.IgnoreList()}
 }
 
-// NewCanonicalSnapshotter creates a new snapshotter rooted at d that produces
+// NewReproducibleSnapshotter creates a new snapshotter rooted at d that produces
 // reproducible snapshots.
-func NewCanonicalSnapshotter(l *LayeredMap, d string) *Snapshotter {
-	return &Snapshotter{l: l, directory: d, ignorelist: util.IgnoreList(), canonical: true}
+func NewReproducibleSnapshotter(l *LayeredMap, d string) *Snapshotter {
+	return &Snapshotter{l: l, directory: d, ignorelist: util.IgnoreList(), reproducible: true}
 }
 
 // Init initializes a new snapshotter
@@ -120,10 +120,10 @@ func (s *Snapshotter) TakeSnapshot(files []string, shdCheckDelete bool, forceBui
 	}
 
 	var t util.Tar
-	if !s.canonical {
+	if !s.reproducible {
 		t = util.NewTar(f)
 	} else {
-		t = util.NewCanonicalTar(f)
+		t = util.NewReproducibleTar(f)
 	}
 	defer t.Close()
 	if err := writeToTar(t, filesToAdd, filesToWhiteout); err != nil {
@@ -141,10 +141,10 @@ func (s *Snapshotter) TakeSnapshotFS() (string, error) {
 	}
 	defer f.Close()
 	var t util.Tar
-	if !s.canonical {
+	if !s.reproducible {
 		t = util.NewTar(f)
 	} else {
-		t = util.NewCanonicalTar(f)
+		t = util.NewReproducibleTar(f)
 	}
 	defer t.Close()
 

--- a/pkg/util/tar_util.go
+++ b/pkg/util/tar_util.go
@@ -38,9 +38,9 @@ import (
 
 // Tar knows how to write files to a tar file.
 type Tar struct {
-	hardlinks map[uint64]string
-	w         *tar.Writer
-	canonical bool
+	hardlinks        map[uint64]string
+	w                *tar.Writer
+	ignoreTimestamps bool
 }
 
 // NewTar will create an instance of Tar that can write files to the writer at f.
@@ -52,14 +52,14 @@ func NewTar(f io.Writer) Tar {
 	}
 }
 
-// NewCanonicalTar will create an instance of Tar that can write files to the
+// NewReproducibleTar will create an instance of Tar that can write files to the
 // writer at f, ignoring timestamps to produce a canonical archive.
-func NewCanonicalTar(f io.Writer) Tar {
+func NewReproducibleTar(f io.Writer) Tar {
 	w := tar.NewWriter(f)
 	return Tar{
-		w:         w,
-		hardlinks: map[uint64]string{},
-		canonical: true,
+		w:                w,
+		hardlinks:        map[uint64]string{},
+		ignoreTimestamps: true,
 	}
 }
 
@@ -110,7 +110,7 @@ func (t *Tar) AddFileToTar(p string) error {
 	if err != nil {
 		return err
 	}
-	if t.canonical {
+	if t.ignoreTimestamps {
 		ct := time.Time{}
 		hdr.ModTime = ct
 


### PR DESCRIPTION
See this in use here: https://github.com/coder/envbuilder/pull/213

This PR adds support for fake builds, essentially a way to detect if a build is cached and what the final image hash should be.

The final image hash requires reproducible builds.

Anothe option to using reproducible builds is to instead tag the final image with the final build step hash.

Part of https://github.com/coder/envbuilder/issues/186

Example output from cache hit (`DoFakeBuild`):

```
#2: fakeStage 0 built successfully with digest sha256:d76c332b89231eb2b8324e28f53ea4f5a394231ee76efdc2a8c8ad11ffd0891b
#2: 🏗️ Built fake image! [1.245278609s]
```

`DoBuild`:

```
#2: Stage 0 built successfully with digest sha256:d76c332b89231eb2b8324e28f53ea4f5a394231ee76efdc2a8c8ad11ffd0891b
#3: 🏗️ Built image! [2.020869675s]
#4: 🏗️ Pushing image...
#2: Pushing image to 172.17.0.3:5000/local/cache
#2: Pushed 172.17.0.3:5000/local/cache@sha256:d76c332b89231eb2b8324e28f53ea4f5a394231ee76efdc2a8c8ad11ffd0891b
#4: 🏗️ Pushed image! [6.134857ms]
```

Example output from cache miss:

```
#2: failed to build fake image: error fake building stage: uncached command *commands.RunMarkerCommand is not supported in fake build
#2: 🏗️ Built fake image! [1.232616498s]
```