### PR TITLE
Refactor image extraction progress to use option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,11 @@ Ignore /var/run when taking image snapshot. Set it to false to preserve
 Set this flag as `--ignore-path=<path>` to ignore path when taking an image
 snapshot. Set it multiple times for multiple ignore paths.
 
+#### Flag `--image-fs-extract-progres`
+
+Set this flag to show the progress of extracting an image filesystem. Defaults
+to `false`.
+
 #### Flag `--image-fs-extract-retry`
 
 Set this flag to the number of retries that should happen for the extracting an

--- a/cmd/executor/cmd/root.go
+++ b/cmd/executor/cmd/root.go
@@ -239,6 +239,7 @@ func addKanikoOptionsFlags() {
 	RootCmd.PersistentFlags().BoolVarP(&opts.SkipTLSVerifyPull, "skip-tls-verify-pull", "", false, "Pull from insecure registry ignoring TLS verify")
 	RootCmd.PersistentFlags().IntVar(&opts.PushRetry, "push-retry", 0, "Number of retries for the push operation")
 	RootCmd.PersistentFlags().BoolVar(&opts.PushIgnoreImmutableTagErrors, "push-ignore-immutable-tag-errors", false, "If true, known tag immutability errors are ignored and the push finishes with success.")
+	RootCmd.PersistentFlags().BoolVar(&opts.ImageFSExtractProgress, "image-fs-extract-progress", false, "Show progress for image FS extraction")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageFSExtractRetry, "image-fs-extract-retry", 0, "Number of retries for image FS extraction")
 	RootCmd.PersistentFlags().IntVar(&opts.ImageDownloadRetry, "image-download-retry", 0, "Number of retries for downloading the remote image")
 	RootCmd.PersistentFlags().StringVarP(&opts.KanikoDir, "kaniko-dir", "", constants.DefaultKanikoPath, "Path to the kaniko directory, this takes precedence over the KANIKO_DIR environment variable.")

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -77,6 +77,7 @@ type KanikoOptions struct {
 	OCILayoutPath            string
 	Compression              Compression
 	CompressionLevel         int
+	ImageFSExtractProgress   bool
 	ImageFSExtractRetry      int
 	SingleSnapshot           bool
 	Reproducible             bool

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -332,7 +332,7 @@ func (s *stageBuilder) build() error {
 		t := timing.Start("FS Unpacking")
 
 		retryFunc := func() error {
-			_, err := getFSFromImage(config.RootDir, s.image, util.ExtractFile)
+			_, err := getFSFromImage(config.RootDir, s.image, util.ExtractFile, s.opts.ImageFSExtractProgress)
 			return err
 		}
 
@@ -939,7 +939,7 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 			if err := saveStageAsTarball(c.From, sourceImage); err != nil {
 				return err
 			}
-			if err := extractImageToDependencyDir(c.From, sourceImage); err != nil {
+			if err := extractImageToDependencyDir(c.From, sourceImage, opts.ImageFSExtractProgress); err != nil {
 				return err
 			}
 		}
@@ -960,7 +960,7 @@ func fromPreviousStage(copyCommand *instructions.CopyCommand, previousStageNames
 	return false
 }
 
-func extractImageToDependencyDir(name string, image v1.Image) error {
+func extractImageToDependencyDir(name string, image v1.Image, extractionProgress bool) error {
 	t := timing.Start("Extracting Image to Dependency Dir")
 	defer timing.DefaultRun.Stop(t)
 	dependencyDir := filepath.Join(config.KanikoDir, name)
@@ -968,7 +968,7 @@ func extractImageToDependencyDir(name string, image v1.Image) error {
 		return err
 	}
 	logrus.Debugf("Trying to extract to %s", dependencyDir)
-	_, err := util.GetFSFromImage(dependencyDir, image, util.ExtractFile)
+	_, err := util.GetFSFromImage(dependencyDir, image, util.ExtractFile, extractionProgress)
 	return err
 }
 

--- a/pkg/executor/build_test.go
+++ b/pkg/executor/build_test.go
@@ -923,7 +923,7 @@ func Test_stageBuilder_build(t *testing.T) {
 		config             *v1.ConfigFile
 		stage              config.KanikoStage
 		crossStageDeps     map[int][]string
-		mockGetFSFromImage func(root string, img v1.Image, extract util.ExtractFunction) ([]string, error)
+		mockGetFSFromImage func(root string, img v1.Image, extract util.ExtractFunction, extractionProgress bool) ([]string, error)
 		shouldInitSnapshot bool
 	}
 
@@ -1441,7 +1441,7 @@ RUN foobar
 			opts:           &config.KanikoOptions{InitialFSUnpacked: true},
 			stage:          config.KanikoStage{Index: 0},
 			crossStageDeps: map[int][]string{0: {"some-dep"}},
-			mockGetFSFromImage: func(root string, img v1.Image, extract util.ExtractFunction) ([]string, error) {
+			mockGetFSFromImage: func(root string, img v1.Image, extract util.ExtractFunction, extractionPogress bool) ([]string, error) {
 				return nil, fmt.Errorf("getFSFromImage shouldn't be called if fs is already unpacked")
 			},
 		},

--- a/pkg/util/fs_util_test.go
+++ b/pkg/util/fs_util_test.go
@@ -1067,6 +1067,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc := io.NopCloser(buf)
@@ -1082,6 +1083,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_enabled(t *testing.T) 
 	f(secondLayerFiles, tw)
 
 	mockLayer2 := mockv1.NewMockLayer(ctrl)
+	mockLayer2.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer2.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc = io.NopCloser(buf)
@@ -1175,6 +1177,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 	layerFiles := []string{
 		filepath.Join(root, "foobar"),
@@ -1197,6 +1200,7 @@ func Test_GetFSFromLayers_with_whiteouts_include_whiteout_disabled(t *testing.T)
 	f(secondLayerFiles, tw)
 
 	mockLayer2 := mockv1.NewMockLayer(ctrl)
+	mockLayer2.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer2.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc = io.NopCloser(buf)
@@ -1280,6 +1284,7 @@ func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 	f(expectedFiles, tw)
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 	layerFiles := []string{
 		filepath.Join(root, ".wh.testdir"),
@@ -1344,6 +1349,8 @@ func Test_GetFSFromLayers_ignorelist(t *testing.T) {
 	tw = tar.NewWriter(buf)
 
 	f(layerFiles, tw)
+
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 
 	rc = io.NopCloser(buf)
 	mockLayer.EXPECT().Uncompressed().Return(rc, nil)
@@ -1410,6 +1417,7 @@ func Test_GetFSFromLayers(t *testing.T) {
 	}
 
 	mockLayer := mockv1.NewMockLayer(ctrl)
+	mockLayer.EXPECT().Size().Return(int64(buf.Len()), nil)
 	mockLayer.EXPECT().MediaType().Return(types.OCILayer, nil)
 
 	rc := io.NopCloser(buf)


### PR DESCRIPTION
I made a branch with plan to upstream this (https://github.com/mafredri/kaniko/tree/mafredri/feat-add-image-fs-extract-progress), this brings the implementation here in line with it.

- **Revert "Add extraction progress output to GetFSFromImage/GetFSFromLayers (#11)"**
- **Add support for showing image FS extraction progress**
