### PR TITLE
fix: remove cached execute for run marker command

### DIFF
--- a/pkg/commands/run_marker.go
+++ b/pkg/commands/run_marker.go
@@ -47,12 +47,6 @@ func (r *RunMarkerCommand) ExecuteCommand(config *v1.Config, buildArgs *dockerfi
 	return nil
 }
 
-func (r *RunMarkerCommand) CachedExecuteCommand(config *v1.Config, buildArgs *dockerfile.BuildArgs) error {
-	// TODO(mafredri): Check if we need to do more here.
-	r.Files = []string{}
-	return nil
-}
-
 // String returns some information about the command for the image config
 func (r *RunMarkerCommand) String() string {
 	return r.cmd.String()

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -509,6 +509,9 @@ func (s *stageBuilder) probeCache() error {
 			case *commands.RunCommand:
 				// If the cache is valid, we expect CachingRunCommand.
 				return errors.Errorf("uncached RUN command is not supported in cache probe mode")
+			case *commands.RunMarkerCommand:
+				// If the cache is valid, we expect CachingRunCommand.
+				return errors.Errorf("uncached RUN command is not supported in cache probe mode")
 			default:
 				return errors.Errorf("unsupported command %T encountered in cache probe mode, missing CachedExecuteCommand", command)
 			}


### PR DESCRIPTION
In #17 we incorrectly added a cached execute method to RunMarkerCommand. These are already translated into CachingRunCommand's when the cache exists.
