### PR TITLE
Add support for imagefs and fix multi-stage cache probing

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -947,6 +947,12 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 // cache without modifying the filesystem.
 // Returns an error if any layers are missing from build cache.
 func DoCacheProbe(opts *config.KanikoOptions) (v1.Image, error) {
+	// Restore the filesystem after we're done since we're using imagefs.
+	origFS := filesystem.FS
+	defer func() {
+		filesystem.SetFS(origFS)
+	}()
+
 	digestToCacheKey := make(map[string]string)
 	stageIdxToDigest := make(map[string]string)
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -17,7 +17,10 @@ limitations under the License.
 package executor
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
+	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -44,6 +47,7 @@ import (
 	"github.com/GoogleContainerTools/kaniko/pkg/filesystem"
 	image_util "github.com/GoogleContainerTools/kaniko/pkg/image"
 	"github.com/GoogleContainerTools/kaniko/pkg/image/remote"
+	"github.com/GoogleContainerTools/kaniko/pkg/imagefs"
 	"github.com/GoogleContainerTools/kaniko/pkg/snapshot"
 	"github.com/GoogleContainerTools/kaniko/pkg/timing"
 	"github.com/GoogleContainerTools/kaniko/pkg/util"
@@ -731,9 +735,10 @@ func (s *stageBuilder) saveLayerToImage(layer v1.Layer, createdBy string) error 
 	return err
 }
 
-func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptions, stageNameToIdx map[string]string) (map[int][]string, error) {
+func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptions, stageNameToIdx map[string]string) (map[int][]string, map[string][]string, error) {
 	images := []v1.Image{}
-	depGraph := map[int][]string{}
+	stageDepGraph := map[int][]string{}
+	imageDepGraph := map[string][]string{}
 	for _, s := range stages {
 		ba := dockerfile.NewBuildArgs(opts.BuildArgs)
 		ba.AddMetaArgs(s.MetaArgs)
@@ -746,12 +751,12 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 		} else {
 			image, err = image_util.RetrieveSourceImage(s, opts)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 		cfg, err := initializeConfig(image, opts)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		cmds, err := dockerfile.GetOnBuildInstructions(&cfg.Config, stageNameToIdx)
@@ -761,29 +766,30 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 			switch cmd := c.(type) {
 			case *instructions.CopyCommand:
 				if cmd.From != "" {
-					i, err := strconv.Atoi(cmd.From)
-					if err != nil {
-						continue
-					}
 					resolved, err := util.ResolveEnvironmentReplacementList(cmd.SourcesAndDest.SourcePaths, ba.ReplacementEnvs(cfg.Config.Env), true)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
-					depGraph[i] = append(depGraph[i], resolved...)
+					i, err := strconv.Atoi(cmd.From)
+					if err == nil {
+						stageDepGraph[i] = append(stageDepGraph[i], resolved...)
+					} else {
+						imageDepGraph[cmd.From] = append(imageDepGraph[cmd.From], resolved...)
+					}
 				}
 			case *instructions.EnvCommand:
 				if err := util.UpdateConfigEnv(cmd.Env, &cfg.Config, ba.ReplacementEnvs(cfg.Config.Env)); err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 				image, err = mutate.Config(image, cfg.Config)
 				if err != nil {
-					return nil, err
+					return nil, nil, err
 				}
 			case *instructions.ArgCommand:
 				for _, arg := range cmd.Args {
 					k, v, err := commands.ParseArg(arg.Key, arg.Value, cfg.Config.Env, ba)
 					if err != nil {
-						return nil, err
+						return nil, nil, err
 					}
 					ba.AddArg(k, v)
 				}
@@ -791,7 +797,7 @@ func CalculateDependencies(stages []config.KanikoStage, opts *config.KanikoOptio
 		}
 		images = append(images, image)
 	}
-	return depGraph, nil
+	return stageDepGraph, imageDepGraph, nil
 }
 
 // DoBuild executes building the Dockerfile
@@ -816,15 +822,17 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, err
 	}
 
-	// Some stages may refer to other random images, not previous stages
-	if err := fetchExtraStages(kanikoStages, opts); err != nil {
-		return nil, err
-	}
-	crossStageDependencies, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
+	crossStageDependencies, imageDependencies, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
 	if err != nil {
 		return nil, err
 	}
 	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
+	logrus.Infof("Built image deps: %v", imageDependencies)
+
+	// Some stages may refer to other random images, not previous stages
+	if err := fetchExtraStages(kanikoStages, opts, false, imageDependencies); err != nil {
+		return nil, err
+	}
 
 	var args *dockerfile.BuildArgs
 
@@ -959,15 +967,16 @@ func DoCacheProbe(opts *config.KanikoOptions) (v1.Image, error) {
 		return nil, err
 	}
 
-	// Some stages may refer to other random images, not previous stages
-	if err := fetchExtraStages(kanikoStages, opts); err != nil {
-		return nil, err
-	}
-	crossStageDependencies, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
+	crossStageDependencies, imageDependencies, err := CalculateDependencies(kanikoStages, opts, stageNameToIdx)
 	if err != nil {
 		return nil, err
 	}
 	logrus.Infof("Built cross stage deps: %v", crossStageDependencies)
+	logrus.Infof("Built image deps: %v", imageDependencies)
+	// Some stages may refer to other random images, not previous stages
+	if err := fetchExtraStages(kanikoStages, opts, true, imageDependencies); err != nil {
+		return nil, err
+	}
 
 	var args *dockerfile.BuildArgs
 
@@ -1020,6 +1029,19 @@ func DoCacheProbe(opts *config.KanikoOptions) (v1.Image, error) {
 
 		digestToCacheKey[d.String()] = sb.finalCacheKey
 		logrus.Infof("Mapping digest %v to cachekey %v", d.String(), sb.finalCacheKey)
+
+		if filesToCache, ok := crossStageDependencies[sb.stage.Index]; ok {
+			ifs, err := imagefs.New(
+				filesystem.FS,
+				filepath.Join(config.KanikoDir, strconv.Itoa(sb.stage.Index)),
+				sourceImage,
+				filesToCache,
+			)
+			if err != nil {
+				return nil, errors.Wrap(err, "could not create image filesystem")
+			}
+			filesystem.SetFS(ifs)
+		}
 
 		if stage.Final {
 			sourceImage, err = mutateCanonicalWithoutLayerEdit(sourceImage)
@@ -1143,7 +1165,7 @@ func deduplicatePaths(paths []string) []string {
 	return deduped
 }
 
-func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) error {
+func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions, cacheProbe bool, imageDependencies map[string][]string) error {
 	t := timing.Start("Fetching Extra Stages")
 	defer timing.DefaultRun.Stop(t)
 
@@ -1177,8 +1199,21 @@ func fetchExtraStages(stages []config.KanikoStage, opts *config.KanikoOptions) e
 			if err := saveStageAsTarball(c.From, sourceImage); err != nil {
 				return err
 			}
-			if err := extractImageToDependencyDir(c.From, sourceImage); err != nil {
-				return err
+			if !cacheProbe {
+				if err := extractImageToDependencyDir(c.From, sourceImage); err != nil {
+					return err
+				}
+			} else {
+				ifs, err := imagefs.New(
+					filesystem.FS,
+					filepath.Join(config.KanikoDir, c.From),
+					sourceImage,
+					imageDependencies[c.From],
+				)
+				if err != nil {
+					return errors.Wrap(err, "could not create image filesystem")
+				}
+				filesystem.SetFS(ifs)
 			}
 		}
 		// Store the name of the current stage in the list with names, if applicable.
@@ -1207,6 +1242,25 @@ func extractImageToDependencyDir(name string, image v1.Image) error {
 	}
 	logrus.Debugf("Trying to extract to %s", dependencyDir)
 	_, err := util.GetFSFromImage(dependencyDir, image, util.ExtractFile)
+	return err
+}
+
+func extractImageFilesToStageDir(stage int, image v1.Image, files []string) error {
+	t := timing.Start("Extracting Image Files to Stage Dir")
+	defer timing.DefaultRun.Stop(t)
+	stageDir := filepath.Join(config.KanikoDir, fmt.Sprintf("%d", stage))
+	if err := filesystem.MkdirAll(stageDir, 0o755); err != nil {
+		return err
+	}
+	_, err := util.GetFSFromImage(stageDir, image, func(dest string, hdr *tar.Header, cleanedName string, tr io.Reader) error {
+		for _, f := range files {
+			if ok, err := path.Match(f, "/"+cleanedName); ok && err == nil {
+				logrus.Infof("Extracting %s", cleanedName)
+				return util.ExtractFile(dest, hdr, cleanedName, tr)
+			}
+		}
+		return nil
+	})
 	return err
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -17,10 +17,7 @@ limitations under the License.
 package executor
 
 import (
-	"archive/tar"
 	"fmt"
-	"io"
-	"path"
 	"path/filepath"
 	"runtime"
 	"sort"
@@ -1242,25 +1239,6 @@ func extractImageToDependencyDir(name string, image v1.Image) error {
 	}
 	logrus.Debugf("Trying to extract to %s", dependencyDir)
 	_, err := util.GetFSFromImage(dependencyDir, image, util.ExtractFile)
-	return err
-}
-
-func extractImageFilesToStageDir(stage int, image v1.Image, files []string) error {
-	t := timing.Start("Extracting Image Files to Stage Dir")
-	defer timing.DefaultRun.Stop(t)
-	stageDir := filepath.Join(config.KanikoDir, fmt.Sprintf("%d", stage))
-	if err := filesystem.MkdirAll(stageDir, 0o755); err != nil {
-		return err
-	}
-	_, err := util.GetFSFromImage(stageDir, image, func(dest string, hdr *tar.Header, cleanedName string, tr io.Reader) error {
-		for _, f := range files {
-			if ok, err := path.Match(f, "/"+cleanedName); ok && err == nil {
-				logrus.Infof("Extracting %s", cleanedName)
-				return util.ExtractFile(dest, hdr, cleanedName, tr)
-			}
-		}
-		return nil
-	})
 	return err
 }
 

--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -830,7 +830,7 @@ func DoBuild(opts *config.KanikoOptions) (v1.Image, error) {
 
 	// Some stages may refer to other random images, not previous stages
 	if err := fetchExtraStages(kanikoStages, opts, false, imageDependencies); err != nil {
-		return nil, errors.Wrap(err, "fetch  extra stages failed")
+		return nil, errors.Wrap(err, "fetch extra stages failed")
 	}
 
 	var args *dockerfile.BuildArgs
@@ -974,7 +974,7 @@ func DoCacheProbe(opts *config.KanikoOptions) (v1.Image, error) {
 	logrus.Infof("Built image deps: %v", imageDependencies)
 	// Some stages may refer to other random images, not previous stages
 	if err := fetchExtraStages(kanikoStages, opts, true, imageDependencies); err != nil {
-		return nil, errors.Wrap(err, "fetch  extra stages failed")
+		return nil, errors.Wrap(err, "fetch extra stages failed")
 	}
 
 	var args *dockerfile.BuildArgs

--- a/pkg/executor/cache_probe_test.go
+++ b/pkg/executor/cache_probe_test.go
@@ -165,8 +165,6 @@ COPY foo/baz.txt copied/
 	})
 
 	t.Run("MultiStage", func(t *testing.T) {
-		t.Skip("TODO: https://github.com/coder/envbuilder/issues/230")
-
 		// Share cache between both builds.
 		regCache := setupCacheRegistry(t)
 
@@ -175,10 +173,12 @@ COPY foo/baz.txt copied/
 			dockerFile := `
 			FROM scratch as first
 			COPY foo/bam.txt copied/
+			COPY foo/bam.link copied/
 			ENV test test
 			
 			From scratch as second
-			COPY --from=first copied/bam.txt output/bam.txt`
+			COPY --from=first copied/bam.txt output/bam.txt
+			COPY --from=first copied/bam.link output/bam.link`
 			err := filesystem.WriteFile(filepath.Join(testDir, "workspace", "Dockerfile"), []byte(dockerFile), 0o755)
 			testutil.CheckNoError(t, err)
 			opts := &config.KanikoOptions{

--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -279,9 +279,9 @@ func hashFile(hdr *tar.Header, r io.Reader) ([]byte, error) {
 
 	h := md5.New()
 	h.Write([]byte(fi.Mode().String()))
-	h.Write([]byte(strconv.FormatUint(uint64(fi.Sys().(*syscall.Stat_t).Uid), 36)))
+	h.Write([]byte(strconv.FormatUint(uint64(hdr.Uid), 36)))
 	h.Write([]byte(","))
-	h.Write([]byte(strconv.FormatUint(uint64(fi.Sys().(*syscall.Stat_t).Gid), 36)))
+	h.Write([]byte(strconv.FormatUint(uint64(hdr.Gid), 36)))
 	if fi.Mode().IsRegular() {
 		if _, err := io.Copy(h, r); err != nil {
 			return nil, errors.Wrap(err, "imagefs: copy file content failed")

--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -1,0 +1,218 @@
+package imagefs
+
+import (
+	"archive/tar"
+	"crypto/md5"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/twpayne/go-vfs/v5"
+
+	"github.com/GoogleContainerTools/kaniko/pkg/util"
+)
+
+type imageFS struct {
+	vfs.FS
+	image map[string]v1.Image
+	dirs  map[string]*cachedDir
+	files map[string]*cachedFileInfo
+}
+
+func New(parent vfs.FS, root string, image v1.Image, filesToCache []string) (vfs.FS, error) {
+	var ifs *imageFS
+
+	// Multiple layers of imageFS might get confusing, enable delayering.
+	if fs, ok := parent.(*imageFS); ok {
+		if _, ok := fs.image[root]; ok {
+			return nil, fmt.Errorf("imagefs: root already exists: %s", root)
+		}
+		fs.image[root] = image
+		ifs = fs
+	} else {
+		ifs = &imageFS{
+			FS:    vfs.NewReadOnlyFS(parent),
+			image: map[string]v1.Image{root: image},
+			dirs:  make(map[string]*cachedDir),
+			files: make(map[string]*cachedFileInfo),
+		}
+	}
+
+	// Walk the image and cache file info and hash of the requested files.
+	_, err := util.GetFSFromImage(root, image, func(dest string, hdr *tar.Header, cleanedName string, tr io.Reader) error {
+		for _, f := range filesToCache {
+			dest := filepath.Join(root, cleanedName)
+
+			// Check if the file matches the requested file.
+			if ok, err := filepath.Match(f, "/"+cleanedName); ok && err == nil {
+				logrus.Debugf("imagefs: Found cacheable file %q (%s) (%d:%d)", f, dest, hdr.Uid, hdr.Gid)
+
+				f := newCachedFileInfo(hdr)
+
+				// Hash the file, implementation must match util.CacheHasher.
+				h := md5.New()
+				h.Write([]byte(f.Mode().String()))
+				h.Write([]byte(strconv.FormatUint(uint64(hdr.Uid), 36)))
+				h.Write([]byte(","))
+				h.Write([]byte(strconv.FormatUint(uint64(hdr.Gid), 36)))
+				if f.Mode().IsRegular() {
+					if _, err := io.Copy(h, tr); err != nil {
+						return err
+					}
+				} else if f.Mode()&os.ModeSymlink == os.ModeSymlink {
+					h.Write([]byte(hdr.Linkname))
+				}
+				f.md5sum = h.Sum(nil)
+
+				ifs.files[dest] = f
+
+				return nil
+			}
+
+			// Parent directories are needed for lookup.
+			if cleanedName == "/" || strings.HasPrefix(f, "/"+cleanedName+"/") {
+				logrus.Debugf("imagefs: Found cacheable file parent %q (%s)", f, dest)
+
+				ifs.files[dest] = newCachedFileInfo(hdr)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to walk image")
+	}
+
+	for dir, d := range ifs.files {
+		if !d.IsDir() {
+			continue
+		}
+		ifs.dirs[dir] = &cachedDir{FileInfo: d}
+		for name, fi := range ifs.files {
+			if filepath.Dir(name) == dir {
+				ifs.dirs[dir].entry = append(ifs.dirs[dir].entry, fi)
+			}
+		}
+	}
+
+	return ifs, nil
+}
+
+func (ifs *imageFS) Open(name string) (fs.File, error) {
+	logrus.Debugf("imagefs: Open file %s", name)
+	if f, err := ifs.FS.Open(name); err == nil {
+		return f, nil
+	}
+	if ifs.files[name] != nil {
+		logrus.Debugf("imagefs: Open cached file %s", name)
+		return ifs.files[name], nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (ifs *imageFS) Lstat(name string) (fs.FileInfo, error) {
+	logrus.Debugf("imagefs: Lstat file %s", name)
+	if fi, err := ifs.FS.Lstat(name); err == nil {
+		return fi, nil
+	}
+	if ifs.files[name] != nil {
+		logrus.Debugf("imagefs: Lstat cached file %s", name)
+		return ifs.files[name], nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (ifs *imageFS) Stat(name string) (fs.FileInfo, error) {
+	logrus.Debugf("imagefs: Stat file %s", name)
+	if fi, err := ifs.FS.Stat(name); err == nil {
+		return fi, nil
+	}
+	if ifs.files[name] != nil {
+		logrus.Debugf("imagefs: Stat cached file %s", name)
+		return ifs.files[name], nil
+	}
+	return nil, fs.ErrNotExist
+}
+
+func (ifs *imageFS) ReadDir(name string) ([]fs.DirEntry, error) {
+	logrus.Debugf("imagefs: Reading directory %s", name)
+	if de, err := ifs.FS.ReadDir(name); err == nil {
+		return de, nil
+	}
+	for dir, d := range ifs.dirs {
+		if ok, err := filepath.Match(name, dir); ok && err == nil {
+			logrus.Debugf("imagefs: Reading cached directory %s", name)
+			return d.entry, nil
+		}
+	}
+	return nil, fs.ErrNotExist
+}
+
+type cachedDir struct {
+	fs.FileInfo
+	entry []fs.DirEntry
+}
+
+type cachedFileInfo struct {
+	fs.FileInfo
+	hdr    *tar.Header
+	sys    interface{}
+	md5sum []byte
+}
+
+// Ensure that cachedFileInfo implements the CacheHasherFileInfoSum interface.
+var _ util.CacheHasherFileInfoSum = &cachedFileInfo{}
+
+func newCachedFileInfo(hdr *tar.Header) *cachedFileInfo {
+	fi := hdr.FileInfo()
+	return &cachedFileInfo{
+		FileInfo: fi,
+		hdr:      hdr,
+		sys: &syscall.Stat_t{
+			Mode: uint32(fi.Mode()),
+			Uid:  uint32(hdr.Uid),
+			Gid:  uint32(hdr.Gid),
+		},
+	}
+}
+
+func (cf *cachedFileInfo) Sys() interface{} {
+	logrus.Debugf("imagefs: Sys cached file %s", cf.Name())
+	return cf.sys
+}
+
+func (cf *cachedFileInfo) Stat() (fs.FileInfo, error) {
+	logrus.Debugf("imagefs: Stat cached file %s", cf.Name())
+	return cf, nil
+}
+
+func (cf *cachedFileInfo) Read(p []byte) (n int, err error) {
+	panic("imagefs: Read cached file is not allowed")
+}
+
+func (cf *cachedFileInfo) MD5Sum() ([]byte, error) {
+	logrus.Debugf("imagefs: MD5Sum cached file %s", cf.Name())
+	return cf.md5sum, nil
+}
+
+func (cf *cachedFileInfo) Type() fs.FileMode {
+	logrus.Debugf("imagefs: Type cached file %s", cf.Name())
+	return cf.Mode()
+}
+
+func (cf *cachedFileInfo) Info() (fs.FileInfo, error) {
+	logrus.Debugf("imagefs: Info cached file %s", cf.Name())
+	return cf, nil
+}
+
+func (cf *cachedFileInfo) Close() error {
+	logrus.Debugf("imagefs: Close cached file %s", cf.Name())
+	return nil
+}

--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package imagefs
 
 import (

--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -192,9 +192,8 @@ func newCachedFileInfo(hdr *tar.Header) *cachedFileInfo {
 		FileInfo: fi,
 		hdr:      hdr,
 		sys: &syscall.Stat_t{
-			Mode: uint32(fi.Mode()),
-			Uid:  uint32(hdr.Uid),
-			Gid:  uint32(hdr.Gid),
+			Uid: uint32(hdr.Uid),
+			Gid: uint32(hdr.Gid),
 		},
 	}
 }

--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -191,10 +191,10 @@ type cachedDir struct {
 }
 
 type cachedFileInfo struct {
-	path string
 	fs.FileInfo
-	hdr *tar.Header
-	sys interface{}
+	path string
+	hdr  *tar.Header
+	sys  *syscall.Stat_t
 }
 
 func newCachedFileInfo(path string, hdr *tar.Header) *cachedFileInfo {


### PR DESCRIPTION
This PR adds support for `imagefs` which currently only supports pre-caching requested files. This means that Dockerfile instructions are resolved ahead of time to figure out which files to cache.

This allows tar archives to be walked once and since files are hashed as-we-go, the implementation is also memory efficient.

Once envbuilder updates to this fork, tha issue https://github.com/coder/envbuilder/issues/230 will be resolved.
