### PR TITLE
fix(pkg/imagefs): add timespec declaration for 32-bit platforms

### DIFF
--- a/pkg/imagefs/imagefs.go
+++ b/pkg/imagefs/imagefs.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"time"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/pkg/errors"
@@ -304,10 +303,6 @@ func tarHeaderToStat_t(hdr *tar.Header) *syscall.Stat_t {
 		Ctim: timespec(hdr.ChangeTime),
 		Mtim: timespec(fi.ModTime()),
 	}
-}
-
-func timespec(t time.Time) syscall.Timespec {
-	return syscall.Timespec{Sec: t.Unix(), Nsec: int64(t.Nanosecond())}
 }
 
 // hashFile hashes the gievn file, implementation must match util.CacheHasher.

--- a/pkg/imagefs/timespec_linux32.go
+++ b/pkg/imagefs/timespec_linux32.go
@@ -1,4 +1,21 @@
 //go:build arm && linux
+// +build arm,linux
+
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package imagefs
 

--- a/pkg/imagefs/timespec_linux32.go
+++ b/pkg/imagefs/timespec_linux32.go
@@ -1,0 +1,12 @@
+//go:build arm && linux
+
+package imagefs
+
+import (
+	"syscall"
+	"time"
+)
+
+func timespec(t time.Time) syscall.Timespec {
+	return syscall.Timespec{Sec: int32(t.Unix()), Nsec: int32(t.Nanosecond())}
+}

--- a/pkg/imagefs/timespec_linux64.go
+++ b/pkg/imagefs/timespec_linux64.go
@@ -1,0 +1,12 @@
+//go:build !arm && linux
+
+package imagefs
+
+import (
+	"syscall"
+	"time"
+)
+
+func timespec(t time.Time) syscall.Timespec {
+	return syscall.Timespec{Sec: t.Unix(), Nsec: int64(t.Nanosecond())}
+}

--- a/pkg/imagefs/timespec_linux64.go
+++ b/pkg/imagefs/timespec_linux64.go
@@ -1,4 +1,21 @@
 //go:build !arm && linux
+// +build !arm,linux
+
+/*
+Copyright 2018 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 package imagefs
 


### PR DESCRIPTION
https://github.com/coder/envbuilder/actions/runs/10631748586 began failing on 32-bit ARM platforms due to differences in the definition of a `sycall.Timespec`.