### PR TITLE
fix: lie about ownership of all files in build context when running as non-root user

### DIFF
--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -24,7 +24,6 @@ import (
 	"io"
 	"math"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -123,8 +122,10 @@ func CacheHasher() func(string) (string, error) {
 		// likely that the file will be owned by the UID/GID that is running
 		// envbuilder, which in this case is not guaranteed to be root.
 		// Let's just pretend that it is, cross our fingers, and hope for the best.
-		lyingAboutOwnership := !fi.IsDir() &&
-			strings.HasSuffix(filepath.Clean(filepath.Dir(p)), ".envbuilder.tmp")
+		isRoot := os.Geteuid() == 0
+		//lyingAboutOwnership := !fi.IsDir() &&
+		//strings.HasSuffix(filepath.Clean(filepath.Dir(p)), ".envbuilder.tmp")
+		lyingAboutOwnership := !fi.IsDir() && !isRoot
 		if lyingAboutOwnership {
 			h.Write([]byte(strconv.FormatUint(uint64(0), 36)))
 			h.Write([]byte(","))


### PR DESCRIPTION
This PR modifies and builds on our previous lies:
- All files in the build context are eligible to have their UID/GID reported as 0:0.
- This will only occur if the process calling Kaniko is running as a non-root user.