### PR TITLE
fix: allow empty run layers to be pushed without force build meta

### DIFF
--- a/pkg/executor/build.go
+++ b/pkg/executor/build.go
@@ -564,7 +564,11 @@ func (s *stageBuilder) takeSnapshot(files []string, shdDelete bool) (string, err
 	} else {
 		// Volumes are very weird. They get snapshotted in the next command.
 		files = append(files, util.Volumes()...)
-		snapshot, err = s.snapshotter.TakeSnapshot(files, shdDelete, s.opts.ForceBuildMetadata)
+		forceBuildMetadata := s.opts.ForceBuildMetadata
+		if s.opts.Cache && len(s.opts.Destinations) > 0 && !s.opts.NoPush {
+			forceBuildMetadata = true
+		}
+		snapshot, err = s.snapshotter.TakeSnapshot(files, shdDelete, forceBuildMetadata)
 	}
 	timing.DefaultRun.Stop(t)
 	return snapshot, err


### PR DESCRIPTION
Images of type application/vnd.docker.image.rootfs.diff.tar.gzip seem to
break when you try to push metadata-only layers and the layers all share
the same hash. This doesn't seem to be a problem with OCI images.

Refs coder/envbuilder#385
