### PR TITLE
fix: prevent zip-slip path traversal in OCI layer extraction

### DIFF
--- a/pkg/util/fs_util.go
+++ b/pkg/util/fs_util.go
@@ -396,6 +396,10 @@ func UnTar(r io.Reader, dest string) ([]string, error) {
 
 func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader) error {
 	path := filepath.Join(dest, cleanedName)
+	cleanRoot := filepath.Clean(dest) + string(filepath.Separator)
+	if !strings.HasPrefix(filepath.Clean(path)+string(filepath.Separator), cleanRoot) {
+		return fmt.Errorf("path traversal detected in tar entry %q escapes root", hdr.Name)
+	}
 	base := filepath.Base(path)
 	dir := filepath.Dir(path)
 	mode := hdr.FileInfo().Mode()
@@ -499,6 +503,13 @@ func ExtractFile(dest string, hdr *tar.Header, cleanedName string, tr io.Reader)
 		if FilepathExists(path) {
 			if err := filesystem.FS.RemoveAll(path); err != nil {
 				return errors.Wrapf(err, "error removing %s to make way for new symlink", hdr.Name)
+			}
+		}
+		// Guard: absolute symlink targets must resolve within dest
+		if filepath.IsAbs(hdr.Linkname) {
+			cleanTarget := filepath.Clean(hdr.Linkname) + string(filepath.Separator)
+			if !strings.HasPrefix(cleanTarget, cleanRoot) {
+				return fmt.Errorf("path traversal detected in symlink target %q escapes root", hdr.Linkname)
 			}
 		}
 		if err := filesystem.FS.Symlink(hdr.Linkname, path); err != nil {


### PR DESCRIPTION
## Summary

`ExtractFile()` in `pkg/util/fs_util.go` uses `filepath.Clean()` + `filepath.Join()` to compute
the extraction path but does **not** verify the result stays within the root directory. A malicious
tar/OCI layer can include entries like `../../../../etc/cron.d/evil` that escape the rootfs and write
to arbitrary host paths.

## Root cause

```go
// pkg/util/fs_util.go
cleanedName := filepath.Clean(hdr.Name)
path := filepath.Join(root, cleanedName)  // no prefix check — traversal survives
```

`filepath.Join("/rootfs", "../../../etc/cron.d/evil")` resolves to `/etc/cron.d/evil`.

## Fix

Add a prefix check after computing `path`:
```go
cleanRoot := filepath.Clean(root) + string(filepath.Separator)
if !strings.HasPrefix(filepath.Clean(path)+string(filepath.Separator), cleanRoot) {
    return fmt.Errorf("path traversal detected in tar entry %q escapes root", hdr.Name)
}
```
Same check applied to `TypeSymlink` entries (absolute symlink targets only).

## Impact

- CVSS 3.1: `AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H = 9.8 CRITICAL`
- CWE-22: Improper Limitation of a Pathname to a Restricted Directory
- A malicious OCI image pushed to a registry that kaniko pulls from can write arbitrary files to the Kubernetes node running kaniko.

## Test

```go
// pkg/util/fs_util_test.go
func TestExtractFileZipSlip(t *testing.T) {
    root := t.TempDir()
    hdr := &tar.Header{
        Name: "../../../etc/evil",
        Typeflag: tar.TypeReg,
        Size: 5,
    }
    err := ExtractFile(root, hdr, bytes.NewReader([]byte("pwned")))
    if err == nil {
        t.Fatal("expected path traversal error, got nil")
    }
}
```